### PR TITLE
feat: 패치노트 크롤링 하여 전체 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
+    // 크롤링
+    implementation 'org.jsoup:jsoup:1.17.2'
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly "org.mariadb.jdbc:mariadb-java-client"

--- a/src/main/java/com/deux/duohaeduo/controller/PatchNoteController.java
+++ b/src/main/java/com/deux/duohaeduo/controller/PatchNoteController.java
@@ -1,0 +1,25 @@
+package com.deux.duohaeduo.controller;
+
+import com.deux.duohaeduo.dto.response.PatchNoteResponse;
+import com.deux.duohaeduo.service.PatchNoteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/lol/patch-notes")
+public class PatchNoteController {
+
+    private final PatchNoteService patchNoteService;
+
+    @GetMapping
+    public List<PatchNoteResponse> crawlPatchNotices() throws IOException {
+        return patchNoteService.findAllPatchNotes();
+    }
+
+}

--- a/src/main/java/com/deux/duohaeduo/dto/response/PatchNoteResponse.java
+++ b/src/main/java/com/deux/duohaeduo/dto/response/PatchNoteResponse.java
@@ -1,0 +1,26 @@
+package com.deux.duohaeduo.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PatchNoteResponse {
+
+    private String subject;
+    private String patchNoteUrl;
+    private String imageUrl;
+
+    public static PatchNoteResponse from(String subject, String patchNoteUrl, String imageUrl) {
+        return PatchNoteResponse.builder()
+                .subject(subject)
+                .patchNoteUrl(patchNoteUrl)
+                .imageUrl(imageUrl)
+                .build();
+    }
+
+}

--- a/src/main/java/com/deux/duohaeduo/service/PatchNoteService.java
+++ b/src/main/java/com/deux/duohaeduo/service/PatchNoteService.java
@@ -1,0 +1,53 @@
+package com.deux.duohaeduo.service;
+
+import com.deux.duohaeduo.dto.response.PatchNoteResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+public class PatchNoteService {
+
+    private static final String LOL_BASE_URL = "https://www.leagueoflegends.com";
+    private static final String PATCH_NOTES_URL = LOL_BASE_URL + "/ko-kr/news/tags/patch-notes/";
+
+    public List<PatchNoteResponse> findAllPatchNotes() throws IOException {
+        Document doc = Jsoup.connect(PATCH_NOTES_URL).get();
+        return getPatchNotes(doc.select(".style__Item-sc-106zuld-3"));
+    }
+
+    private List<PatchNoteResponse> getPatchNotes(Elements items) {
+        List<PatchNoteResponse> patchNotes = new ArrayList<>();
+        for (Element item : items) {
+            PatchNoteResponse patchNote = crawlPatchNoteItem(item);
+            if (patchNote == null) {
+                throw new IllegalArgumentException("패치 노트 정보가 없습니다.");
+            }
+            patchNotes.add(patchNote);
+        }
+        return patchNotes;
+    }
+
+    private PatchNoteResponse crawlPatchNoteItem(Element item) {
+        Element titleElement = item.selectFirst(".style__Title-sc-1h41bzo-8");
+        Element linkElement = item.selectFirst(".style__Wrapper-sc-1h41bzo-0");
+        Element imageElement = item.selectFirst(".style__ImageWrapper-sc-1h41bzo-5 img");
+
+        if (titleElement == null || linkElement == null || imageElement == null) {
+            return null;
+        }
+        return PatchNoteResponse.from(
+                titleElement.text(),
+                LOL_BASE_URL + linkElement.attr("href"),
+                imageElement.attr("src"));
+    }
+
+}


### PR DESCRIPTION
# Changes
- 리그오브레전드 패치 노트 데이터 크롤링하여 전체 조회하는 기능 추가하였습니다.

# Execute
- [x] 포스트맨 테스트 완료