### PR TITLE
feature: 스케줄러를 활용하여 빌드할 때 db 에 저장하는 기능 추가

### DIFF
--- a/src/main/java/com/deux/duohaeduo/DuoHaeDuoApplication.java
+++ b/src/main/java/com/deux/duohaeduo/DuoHaeDuoApplication.java
@@ -2,12 +2,14 @@ package com.deux.duohaeduo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class DuoHaeDuoApplication {
 
-  public static void main(String[] args) {
-    SpringApplication.run(DuoHaeDuoApplication.class, args);
-  }
+    public static void main(String[] args) {
+        SpringApplication.run(DuoHaeDuoApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/deux/duohaeduo/dto/ChampionPayload.java
+++ b/src/main/java/com/deux/duohaeduo/dto/ChampionPayload.java
@@ -35,6 +35,10 @@ public class ChampionPayload {
 
     private int keywordCount;
 
+    private String championIconUrl;
+
+    private String championRiotKey;
+
     public static ChampionPayload from(Champion champion) {
         return ChampionPayload.builder()
                 .id(champion.getId())
@@ -47,6 +51,8 @@ public class ChampionPayload {
                 .ultimateType(champion.getUltimateType())
                 .skillDetails(champion.getSkillDetails())
                 .position(champion.getPosition())
+                .championIconUrl(champion.getChampionIconUrl())
+                .championRiotKey(champion.getChampionRiotKey())
                 .build();
     }
 

--- a/src/main/java/com/deux/duohaeduo/dto/response/FindAllRotationChampionsResponse.java
+++ b/src/main/java/com/deux/duohaeduo/dto/response/FindAllRotationChampionsResponse.java
@@ -1,5 +1,6 @@
 package com.deux.duohaeduo.dto.response;
 
+import com.deux.duohaeduo.entity.Champion;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,11 +14,12 @@ import java.util.List;
 @AllArgsConstructor
 public class FindAllRotationChampionsResponse {
 
-    private List<String> rotationChampionNames;
+    private List<Champion> rotationChampions;
 
-    public static FindAllRotationChampionsResponse from(List<String> rotationChampionNames) {
+    public static FindAllRotationChampionsResponse from(List<Champion> rotationChampions) {
         return FindAllRotationChampionsResponse.builder()
-                .rotationChampionNames(rotationChampionNames)
+                .rotationChampions(rotationChampions)
                 .build();
     }
+
 }

--- a/src/main/java/com/deux/duohaeduo/entity/Champion.java
+++ b/src/main/java/com/deux/duohaeduo/entity/Champion.java
@@ -35,8 +35,14 @@ public class Champion {
     @URL
     private String championIconUrl;
 
-    public void saveChampionIconUrl(String championIconUrl) {
+    private String championRiotKey;
+
+    public void addChampionIconUrl(String championIconUrl) {
         this.championIconUrl = championIconUrl;
+    }
+
+    public void addChampionRiotKey(String championRiotKey) {
+        this.championRiotKey = championRiotKey;
     }
 
 }

--- a/src/main/java/com/deux/duohaeduo/service/SingleService.java
+++ b/src/main/java/com/deux/duohaeduo/service/SingleService.java
@@ -26,15 +26,12 @@ public class SingleService {
     public FindGameMemberInfoResponse findGameUserInfo(FindGameUserInfoRequest findGameUserInfoRequest) throws IOException, JSONException {
         long matchCount = 20L;
         List<String> nicknameAndTag = List.of(findGameUserInfoRequest.getGameNickname().split("#"));
-        System.out.println(nicknameAndTag.get(0));
-
         String tag;
         if (nicknameAndTag.size() != 1) {
             tag = nicknameAndTag.get(1);
         } else {
             tag = "KR1";
         }
-
         FindGameMemberInfo findGameMemberInfo = riotService.findRiotGameMemberInfo(nicknameAndTag.get(0), tag, 1L, matchCount);
         return new FindGameMemberInfoResponse(groupService.convertRiotSummonerInfo(findGameMemberInfo, nicknameAndTag.get(0), tag));
     }


### PR DESCRIPTION
# Changes
- 로테이션 챔피언 조회 메소드에서 반환타입 및 메소드 내에 일부 코드를 수정하였습니다.
- riot 에서 제공하는 championIconUrl & championRiotKey 스케줄러를 활용하여 빌드할 때 Champion 엔티티에 자동 저장하는 save() 기능을 추가하였습니다.
- FindAllRotationChampionsResponse 필드 변수 & from() 메서드 수정하였습니다.
- SingleService 클래스 불필요한 코드 삭제하였습니다.

# Execute
- [x] 포스트맨 테스트